### PR TITLE
Make auth/signin request secure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8] - 2020-10-15
+### Changed
+- Use https when making requests to auth/signin
+
 ## [0.3.7] - 2020-08-22
 ### Changed
 - Updated the README to follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) by [@jquass](https://github.com/jquass)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,6 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/jquass
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
 
-## Code of Conductir
+## Code of Conduct
 
 Everyone interacting in the SWGOH::API project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/jquass/SWGOH-API/blob/master/CODE_OF_CONDUCT.md).

--- a/lib/SWGOH/API/CLIENT/client.rb
+++ b/lib/SWGOH/API/CLIENT/client.rb
@@ -26,7 +26,7 @@ class CLIENT
   # @return [String | nil]
   def authorize(username, password)
     form = auth_request_form(username, password)
-    path = "http://#{SWGOH::API::PATH::BASE}/#{SWGOH::API::PATH::AUTH_SIGNIN}"
+    path = "https://#{SWGOH::API::PATH::BASE}/#{SWGOH::API::PATH::AUTH_SIGNIN}"
     res = Net::HTTP.post_form(URI(path), form)
     return unless res.is_a?(Net::HTTPSuccess)
 


### PR DESCRIPTION
Unsecure requests are now failing (as they rightly should be).